### PR TITLE
Fix path to example workflow in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please ensure your ComfyUI version is newer than commit `c496e53`.
 
 ### Running the Workflow
 
-[Reference Workflow for FLUX](./workflows/taylorseer_example_flux.json)
+[Reference Workflow for FLUX](./examples/taylorseer_example_flux.json)
 
 ## Usage Instructions
 


### PR DESCRIPTION
Change folder name 'workflows' to 'examples' in the file path